### PR TITLE
Login popup

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -45,3 +45,5 @@ export {
   DELETE_DOWNLOADTOOL,
   deleteDownloadtool,
 } from './downloadtool/delete_downloadtool';
+
+export { GET_REGISTRY, getRegistry } from './registry/registry';

--- a/src/actions/registry/registry.js
+++ b/src/actions/registry/registry.js
@@ -15,7 +15,7 @@ export function getRegistry(registry_key) {
     registry_key: registry_key,
     request: {
       op: 'get',
-      path: `/@registry/${registry_key}`,
+      path: `/@anon-registry/${registry_key}`,
     },
   };
 }

--- a/src/actions/registry/registry.js
+++ b/src/actions/registry/registry.js
@@ -12,6 +12,7 @@ export const GET_REGISTRY = 'GET_REGISTRY';
 export function getRegistry(registry_key) {
   return {
     type: GET_REGISTRY,
+    registry_key: registry_key,
     request: {
       op: 'get',
       path: `/@registry/${registry_key}`,

--- a/src/actions/registry/registry.js
+++ b/src/actions/registry/registry.js
@@ -1,0 +1,20 @@
+/**
+ * Get cart selection to downloadtool.
+ * @module actions/registry
+ */
+export const GET_REGISTRY = 'GET_REGISTRY';
+
+/**
+ * Get cart selection to registry.
+ * @function GetRegistry
+ * @returns {Object} Get extra items action.
+ */
+export function getRegistry(registry_key) {
+  return {
+    type: GET_REGISTRY,
+    request: {
+      op: 'get',
+      path: `/@registry/${registry_key}`,
+    },
+  };
+}

--- a/src/components/CclLoginModal/CclLoginModal.jsx
+++ b/src/components/CclLoginModal/CclLoginModal.jsx
@@ -5,6 +5,7 @@ import CclButton from '@eeacms/volto-clms-theme/components/CclButton/CclButton';
 import { useDispatch, useSelector } from 'react-redux';
 import { getRegistry } from '@eeacms/volto-clms-theme/actions';
 import { FormattedMessage } from 'react-intl';
+import config from '@plone/volto/registry';
 import './ccl-login-modal.css';
 /**
  * Login Modal component doc.
@@ -16,16 +17,20 @@ function CclLoginModal() {
   const dispatch = useDispatch();
   const registryRecords = useSelector((state) => state.registry.records);
   const [loginUrl, setLoginUrl] = React.useState('');
-  const registry_key = 'clms.addon.login_url_controlpanel.login_url';
-  useEffect(() => {
-    dispatch(getRegistry(registry_key));
-  }, [dispatch]);
+  const registry_key = config.settings?.registry?.login_url || null;
 
   useEffect(() => {
     if (registryRecords && registry_key in registryRecords) {
       setLoginUrl(registryRecords[registry_key]);
     }
-  }, [registryRecords]);
+  }, [registryRecords, registry_key]);
+
+  function modalStatus(status) {
+    if (status === true) {
+      dispatch(getRegistry(registry_key));
+    }
+  }
+
   return (
     <CclModal
       trigger={
@@ -37,9 +42,10 @@ function CclLoginModal() {
         </div>
       }
       size="fullscreen"
+      modalStatus={modalStatus}
     >
-      <div class="modal-login-title">Login</div>
-      <div class="modal-login-text">
+      <div className="modal-login-title">Login</div>
+      <div className="modal-login-text">
         Registration is free. Personal data will only be used internally. more
         details, see the{' '}
         <a href="./personal-data-protection.html" target="_blank">

--- a/src/components/CclLoginModal/CclLoginModal.jsx
+++ b/src/components/CclLoginModal/CclLoginModal.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import CclModal from '@eeacms/volto-clms-theme/components/CclModal/CclModal';
+import CclButton from '@eeacms/volto-clms-theme/components/CclButton/CclButton';
+import { useDispatch } from 'react-redux';
+import { getRegistry } from '@eeacms/volto-clms-theme/actions';
+import { FormattedMessage } from 'react-intl';
+import './ccl-login-modal.css';
+/**
+ * Login Modal component doc.
+ * @function CclLoginModal
+ * @example <CclLoginModal />
+ *
+ */
+function CclLoginModal() {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(getRegistry());
+  }, null);
+
+  return (
+    <CclModal
+      trigger={
+        <div className="header-login-link">
+          <FormattedMessage
+            id="loginRegister"
+            defaultMessage="Register/Login"
+          />
+        </div>
+      }
+      size="fullscreen"
+    >
+      <div class="modal-login-title">Login</div>
+      <div class="modal-login-text">
+        Registration is free. Personal data will only be used internally. more
+        details, see the{' '}
+        <a href="./personal-data-protection.html" target="_blank">
+          Personal data protection
+        </a>
+        .
+      </div>
+      <CclButton url="#" mode="filled">
+        Login
+      </CclButton>
+    </CclModal>
+  );
+}
+
+CclLoginModal.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  marginBottom: PropTypes.bool,
+};
+export default CclLoginModal;

--- a/src/components/CclLoginModal/CclLoginModal.jsx
+++ b/src/components/CclLoginModal/CclLoginModal.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import CclModal from '@eeacms/volto-clms-theme/components/CclModal/CclModal';
 import CclButton from '@eeacms/volto-clms-theme/components/CclButton/CclButton';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { getRegistry } from '@eeacms/volto-clms-theme/actions';
 import { FormattedMessage } from 'react-intl';
 import './ccl-login-modal.css';
@@ -14,10 +14,18 @@ import './ccl-login-modal.css';
  */
 function CclLoginModal() {
   const dispatch = useDispatch();
+  const registryRecords = useSelector((state) => state.registry.records);
+  const [loginUrl, setLoginUrl] = React.useState('');
+  const registry_key = 'clms.addon.login_url_controlpanel.login_url';
   useEffect(() => {
-    dispatch(getRegistry());
-  }, null);
+    dispatch(getRegistry(registry_key));
+  }, [dispatch]);
 
+  useEffect(() => {
+    if (registryRecords && registry_key in registryRecords) {
+      setLoginUrl(registryRecords[registry_key]);
+    }
+  }, [registryRecords]);
   return (
     <CclModal
       trigger={
@@ -39,7 +47,7 @@ function CclLoginModal() {
         </a>
         .
       </div>
-      <CclButton url="#" mode="filled">
+      <CclButton url={loginUrl || ''} mode="filled">
         Login
       </CclButton>
     </CclModal>

--- a/src/components/CclLoginModal/ccl-login-modal.css
+++ b/src/components/CclLoginModal/ccl-login-modal.css
@@ -1,0 +1,3 @@
+.modal-clms-container {
+  max-width: 460px;
+}

--- a/src/components/CclLoginModal/ccl-login-modal.css
+++ b/src/components/CclLoginModal/ccl-login-modal.css
@@ -1,3 +1,7 @@
+.header-login-link {
+  color: white;
+}
+
 .modal-clms-container {
   max-width: 460px;
 }

--- a/src/components/CclModal/CclModal.jsx
+++ b/src/components/CclModal/CclModal.jsx
@@ -3,13 +3,23 @@ import { Modal } from 'semantic-ui-react';
 import './modal.less';
 
 function CclModal(props) {
+  let { trigger, children, size, modalStatus } = props;
   const [open, setOpen] = React.useState(false);
-  let { trigger, children, size } = props;
+
+  function openModal() {
+    setOpen(true);
+    modalStatus(true);
+  }
+
+  function closeModal() {
+    setOpen(false);
+    modalStatus(false);
+  }
 
   return (
     <Modal
-      onClose={() => setOpen(false)}
-      onOpen={() => setOpen(true)}
+      onClose={() => closeModal()}
+      onOpen={() => openModal()}
       open={open}
       trigger={trigger}
       className={'modal-clms'}
@@ -21,8 +31,8 @@ function CclModal(props) {
             <span
               className="ccl-icon-close"
               aria-label="Close"
-              onClick={() => setOpen(false)}
-              onKeyDown={() => setOpen(false)}
+              onClick={() => closeModal()}
+              onKeyDown={() => closeModal()}
               tabIndex="0"
               role="button"
             ></span>

--- a/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/src/customizations/volto/components/theme/Header/Header.jsx
@@ -25,6 +25,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { getCartItems } from '@eeacms/volto-clms-theme/actions';
 import '@eeacms/volto-clms-theme/../theme/clms/css/header.css';
 import { Link } from 'react-router-dom';
+import CclLoginModal from '@eeacms/volto-clms-theme/components/CclLoginModal/CclLoginModal';
 // import useCartState from '@eeacms/volto-clms-theme/utils/useCartState';
 
 const CartIconCounter = (props) => {
@@ -197,15 +198,16 @@ class Header extends Component {
                           )}
                       </>
                     )) || (
-                      <Link
-                        to={`/${this.props.locale}/login`}
-                        className="header-login-link"
-                      >
-                        <FormattedMessage
-                          id="loginRegister"
-                          defaultMessage="Register/Login"
-                        />
-                      </Link>
+                      <CclLoginModal />
+                      // <Link
+                      //   to={`/${this.props.locale}/login`}
+                      //   className="header-login-link"
+                      // >
+                      //   <FormattedMessage
+                      //     id="loginRegister"
+                      //     defaultMessage="Register/Login"
+                      //   />
+                      // </Link>
                     )}
                   </li>
                 </ul>

--- a/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/src/customizations/volto/components/theme/Header/Header.jsx
@@ -197,18 +197,7 @@ class Header extends Component {
                             </>
                           )}
                       </>
-                    )) || (
-                      <CclLoginModal />
-                      // <Link
-                      //   to={`/${this.props.locale}/login`}
-                      //   className="header-login-link"
-                      // >
-                      //   <FormattedMessage
-                      //     id="loginRegister"
-                      //     defaultMessage="Register/Login"
-                      //   />
-                      // </Link>
-                    )}
+                    )) || <CclLoginModal />}
                   </li>
                 </ul>
                 <div

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,12 @@ const applyConfig = (config) => {
       'sv',
     ],
     defaultLanguage: 'en',
+    registry: {
+      ...config.settings.registry,
+      login_url: 'clms.addon.login_url_controlpanel.login_url',
+    },
   };
+
   config.addonRoutes = [
     ...config.addonRoutes,
     {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,6 +10,7 @@ import { extraBreadcrumbItemsReducer } from './extra_breadcrumbs/extra_breadcrum
 import { meetingRegisterReducer } from './meeting/meeting_register_reducer';
 import { meetingSubscribersReducer } from './meeting/meeting_subscribers_reducer';
 import { downloadtoolReducer } from './downloadtool/downloadtool_reducer';
+import { registryReducer } from './registry/registry';
 
 /**
  * Root reducer.
@@ -27,6 +28,7 @@ const reducers = {
   meeting_register: meetingRegisterReducer,
   subscribers: meetingSubscribersReducer,
   downloadtool: downloadtoolReducer,
+  registry: registryReducer,
 };
 
 export default reducers;

--- a/src/reducers/registry/registry.js
+++ b/src/reducers/registry/registry.js
@@ -1,0 +1,43 @@
+/**
+ * Registry reducer.
+ * @module reducers/registry
+ */
+
+import { GET_REGISTRY } from '../../actions';
+
+const getInitialState = {
+  error: null,
+  loaded: false,
+  loading: false,
+  registry: {},
+};
+
+export const registryReducer = (state = getInitialState, action = {}) => {
+  switch (action?.type) {
+    case `${GET_REGISTRY}_PENDING`:
+      return {
+        ...state,
+        error: null,
+        loaded: false,
+        loading: true,
+      };
+    case `${GET_REGISTRY}_FAIL`:
+      return {
+        ...state,
+        error: action.error,
+        loaded: false,
+        loading: false,
+      };
+
+    case `${GET_REGISTRY}_SUCCESS`:
+      return {
+        ...state,
+        error: null,
+        loaded: true,
+        loading: false,
+        registry: action.result,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/reducers/registry/registry.js
+++ b/src/reducers/registry/registry.js
@@ -9,7 +9,7 @@ const getInitialState = {
   error: null,
   loaded: false,
   loading: false,
-  registry: {},
+  records: {},
 };
 
 export const registryReducer = (state = getInitialState, action = {}) => {

--- a/src/reducers/registry/registry.js
+++ b/src/reducers/registry/registry.js
@@ -13,7 +13,6 @@ const getInitialState = {
 };
 
 export const registryReducer = (state = getInitialState, action = {}) => {
-  console.log('registryReducer', state, action);
   switch (action?.type) {
     case `${GET_REGISTRY}_PENDING`:
       return {
@@ -36,8 +35,8 @@ export const registryReducer = (state = getInitialState, action = {}) => {
         error: null,
         loaded: true,
         loading: false,
-        registry: {
-          ...state.registry,
+        records: {
+          ...state.records,
           [action.registry_key]: action.result,
         },
       };

--- a/src/reducers/registry/registry.js
+++ b/src/reducers/registry/registry.js
@@ -13,6 +13,7 @@ const getInitialState = {
 };
 
 export const registryReducer = (state = getInitialState, action = {}) => {
+  console.log('registryReducer', state, action);
   switch (action?.type) {
     case `${GET_REGISTRY}_PENDING`:
       return {
@@ -35,7 +36,10 @@ export const registryReducer = (state = getInitialState, action = {}) => {
         error: null,
         loaded: true,
         loading: false,
-        registry: action.result,
+        registry: {
+          ...state.registry,
+          [action.registry_key]: action.result,
+        },
       };
     default:
       return state;


### PR DESCRIPTION
* Added an action to request values from @registry https://github.com/eea/volto-clms-theme/blob/login-popup/src/actions/registry/registry.js
* Added a dictionary of keys values in confing.settings.registry to be able to add different keys in the general configuration of the frontend. https://github.com/eea/volto-clms-theme/blob/login-popup/src/index.js#L97
* Added a callback in the CclModal component to have the status of the modal(opened/closed) from the child to the parent. https://github.com/eea/volto-clms-theme/blob/login-popup/src/components/CclModal/CclModal.jsx#L11 
How to use: https://github.com/eea/volto-clms-theme/blob/login-popup/src/components/CclLoginModal/CclLoginModal.jsx#L45
* Added the login modal in the header that contains the login button.
The login button will redirect to the eea login dynamically depending on the registry value. https://github.com/eea/volto-clms-theme/blob/login-popup/src/components/CclLoginModal/CclLoginModal.jsx

![demo](https://user-images.githubusercontent.com/26112509/143573847-cb95901d-0785-4158-817f-2cd70ddd9215.png)
