### PR TITLE
change no related item message

### DIFF
--- a/src/components/Blocks/CclRelatedListingBlock/CclRelatedListingView.jsx
+++ b/src/components/Blocks/CclRelatedListingBlock/CclRelatedListingView.jsx
@@ -68,7 +68,7 @@ const CclRelatedListingView = (props) => {
       {searchSubrequests?.loaded && libraries.length > 0 ? (
         <TemplateView items={libraries} variation={template_id} />
       ) : (
-        <p>There are no related {data.content_type} items.</p>
+        <p>There are no related items.</p>
       )}
       {searchSubrequests?.loading && <Segment loading></Segment>}
     </>


### PR DESCRIPTION
Remove the content-type from here, otherwise we are showing "eea.meeting" instead of "Event", and adding a vocabulary call to get the real portal-type adds a little gain.