### PR TITLE
feat: use slate link editor with internal/external link editor and ad…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,9 @@ import CookieBanner from 'volto-cookie-banner/CookieBannerContainer';
 import CLMSLoginView from './components/CLMSLoginView/CLMSLogin';
 // import Login from '@plone/volto/components/Login';
 
+// custom link plugin for slate link inserter
+import installEditor from 'volto-slate/editor/plugins/Link';
+
 const applyConfig = (config) => {
   config.views = {
     ...config.views,
@@ -257,6 +260,9 @@ const applyConfig = (config) => {
     ...config.addonReducers,
     ...reducers,
   };
+
+  config = installEditor(config);
+
   return config;
 };
 export default applyConfig;


### PR DESCRIPTION
This way we have an "advanced" link editor with several options:

link to internal/external items
link to emails
link to anchors
etc.

See https://github.com/eea/clms-frontend/pull/162 for frontend changes related to this PR

please test before merging @UnaiEtxaburu @ionlizarazu 

