### PR TITLE
use querystringsearch endpoint as GET and not POST

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,6 +135,7 @@ const applyConfig = (config) => {
         component: CustomMatomoAppExtra,
       },
     ],
+    querystringSearchGet: true,
     nonContentRoutes: [
       ...config.settings.nonContentRoutes,
       '/profile',


### PR DESCRIPTION
We need to test this setting properly.

See the reference PRs:
- https://github.com/plone/volto/pull/4658
- https://github.com/plone/plone.restapi/issues/1252
- https://github.com/plone/volto/pull/5206