### PR TITLE
feat: add a component to show admins the sorting information of a technical library item

### DIFF
--- a/src/components/CLMSTechnicalLibraryAdminInfo/CLMSTechnicalLibraryAdminInfo.jsx
+++ b/src/components/CLMSTechnicalLibraryAdminInfo/CLMSTechnicalLibraryAdminInfo.jsx
@@ -19,35 +19,32 @@ const CLMSTechnicalLibraryAdminInfo = (props) => {
     !queryItem?.loaded &&
     dispatch(getContent(id, null, uid));
 
-  return (
-    isLoggedIn &&
-    isManager && (
-      <>
-        {showThis[`${uid}`] && item ? (
-          <>
-            <br />
-            <Button onClick={() => setShowThis({ ...showThis, [uid]: false })}>
-              Hide
-            </Button>
-            <br />
-            <strong>Categorization</strong>
-            <ul>
-              {item?.taxonomy_technical_library_categorization.map((item) => (
-                <li>{item.title}</li>
-              ))}
-            </ul>
-          </>
-        ) : (
-          <>
-            <br />
-            <Button onClick={() => setShowThis({ ...showThis, [uid]: true })}>
-              Show extra data
-            </Button>
-          </>
-        )}
-      </>
-    )
-  );
+  return isLoggedIn && isManager ? (
+    <>
+      {showThis[`${uid}`] && item ? (
+        <>
+          <br />
+          <Button onClick={() => setShowThis({ ...showThis, [uid]: false })}>
+            Hide
+          </Button>
+          <br />
+          <strong>Categorization</strong>
+          <ul>
+            {item?.taxonomy_technical_library_categorization.map((item) => (
+              <li>{item.title}</li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <>
+          <br />
+          <Button onClick={() => setShowThis({ ...showThis, [uid]: true })}>
+            Show extra data
+          </Button>
+        </>
+      )}
+    </>
+  ) : null;
 };
 
 export { CLMSTechnicalLibraryAdminInfo };

--- a/src/components/CLMSTechnicalLibraryAdminInfo/CLMSTechnicalLibraryAdminInfo.jsx
+++ b/src/components/CLMSTechnicalLibraryAdminInfo/CLMSTechnicalLibraryAdminInfo.jsx
@@ -19,33 +19,34 @@ const CLMSTechnicalLibraryAdminInfo = (props) => {
     !queryItem?.loaded &&
     dispatch(getContent(id, null, uid));
 
-  return isLoggedIn && isManager ? (
-    <>
-      {showThis[`${uid}`] && item ? (
-        <>
-          <br />
-          <Button onClick={() => setShowThis({ ...showThis, [uid]: false })}>
-            Hide
-          </Button>
-          <br />
-          <strong>Categorization</strong>
-          <ul>
-            {item?.taxonomy_technical_library_categorization.map((item) => (
-              <li>{item.title}</li>
-            ))}
-          </ul>
-        </>
-      ) : (
-        <>
-          <br />
-          <Button onClick={() => setShowThis({ ...showThis, [uid]: true })}>
-            Show extra data
-          </Button>
-        </>
-      )}
-    </>
-  ) : (
-    ''
+  return (
+    isLoggedIn &&
+    isManager && (
+      <>
+        {showThis[`${uid}`] && item ? (
+          <>
+            <br />
+            <Button onClick={() => setShowThis({ ...showThis, [uid]: false })}>
+              Hide
+            </Button>
+            <br />
+            <strong>Categorization</strong>
+            <ul>
+              {item?.taxonomy_technical_library_categorization.map((item) => (
+                <li>{item.title}</li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <>
+            <br />
+            <Button onClick={() => setShowThis({ ...showThis, [uid]: true })}>
+              Show extra data
+            </Button>
+          </>
+        )}
+      </>
+    )
   );
 };
 

--- a/src/components/CLMSTechnicalLibraryAdminInfo/CLMSTechnicalLibraryAdminInfo.jsx
+++ b/src/components/CLMSTechnicalLibraryAdminInfo/CLMSTechnicalLibraryAdminInfo.jsx
@@ -1,0 +1,47 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { getContent } from '@plone/volto/actions';
+import React, { useState } from 'react';
+import { Button } from 'semantic-ui-react';
+
+const CLMSTechnicalLibraryAdminInfo = (props) => {
+  const { uid, id } = props;
+  const [showThis, setShowThis] = useState({});
+  const isLoggedIn = useSelector((state) => state.userSession?.token);
+  const user = useSelector((state) => state.users?.user);
+  const isManager = user?.roles ? user?.roles.includes('Manager') : false;
+  const dispatch = useDispatch();
+  const contents = useSelector((state) => state.content?.subrequests);
+  const queryItem = contents?.[`${uid}`];
+  const item = queryItem?.data;
+  const show = isLoggedIn && isManager && item && showThis[`${uid}`];
+
+  showThis?.[`${uid}`] &&
+    !queryItem?.loading &&
+    !queryItem?.loaded &&
+    dispatch(getContent(id, null, uid));
+
+  return show ? (
+    <>
+      <br />
+      <Button onClick={() => setShowThis({ ...showThis, [uid]: false })}>
+        Hide
+      </Button>
+      <br />
+      <strong>Categorization</strong>
+      <ul>
+        {item?.taxonomy_technical_library_categorization.map((item) => (
+          <li>{item.title}</li>
+        ))}
+      </ul>
+    </>
+  ) : (
+    <>
+      <br />
+      <Button onClick={() => setShowThis({ ...showThis, [uid]: true })}>
+        Show extra data
+      </Button>
+    </>
+  );
+};
+
+export { CLMSTechnicalLibraryAdminInfo };

--- a/src/components/CLMSTechnicalLibraryAdminInfo/CLMSTechnicalLibraryAdminInfo.jsx
+++ b/src/components/CLMSTechnicalLibraryAdminInfo/CLMSTechnicalLibraryAdminInfo.jsx
@@ -13,34 +13,39 @@ const CLMSTechnicalLibraryAdminInfo = (props) => {
   const contents = useSelector((state) => state.content?.subrequests);
   const queryItem = contents?.[`${uid}`];
   const item = queryItem?.data;
-  const show = isLoggedIn && isManager && item && showThis[`${uid}`];
 
   showThis?.[`${uid}`] &&
     !queryItem?.loading &&
     !queryItem?.loaded &&
     dispatch(getContent(id, null, uid));
 
-  return show ? (
+  return isLoggedIn && isManager ? (
     <>
-      <br />
-      <Button onClick={() => setShowThis({ ...showThis, [uid]: false })}>
-        Hide
-      </Button>
-      <br />
-      <strong>Categorization</strong>
-      <ul>
-        {item?.taxonomy_technical_library_categorization.map((item) => (
-          <li>{item.title}</li>
-        ))}
-      </ul>
+      {showThis[`${uid}`] && item ? (
+        <>
+          <br />
+          <Button onClick={() => setShowThis({ ...showThis, [uid]: false })}>
+            Hide
+          </Button>
+          <br />
+          <strong>Categorization</strong>
+          <ul>
+            {item?.taxonomy_technical_library_categorization.map((item) => (
+              <li>{item.title}</li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <>
+          <br />
+          <Button onClick={() => setShowThis({ ...showThis, [uid]: true })}>
+            Show extra data
+          </Button>
+        </>
+      )}
     </>
   ) : (
-    <>
-      <br />
-      <Button onClick={() => setShowThis({ ...showThis, [uid]: true })}>
-        Show extra data
-      </Button>
-    </>
+    ''
   );
 };
 

--- a/src/components/CLMSTechnicalLibraryAdminInfo/index.js
+++ b/src/components/CLMSTechnicalLibraryAdminInfo/index.js
@@ -1,0 +1,3 @@
+import { CLMSTechnicalLibraryAdminInfo } from './CLMSTechnicalLibraryAdminInfo';
+
+export { CLMSTechnicalLibraryAdminInfo };

--- a/src/components/CclCard/CclCard.jsx
+++ b/src/components/CclCard/CclCard.jsx
@@ -17,6 +17,7 @@ import { FormattedMessage } from 'react-intl';
 import CclLoginModal from '@eeacms/volto-clms-theme/components/CclLoginModal/CclLoginModal';
 import CclButton from '@eeacms/volto-clms-theme/components/CclButton/CclButton';
 import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
+import { CLMSTechnicalLibraryAdminInfo } from '../CLMSTechnicalLibraryAdminInfo';
 
 const CardImage = ({ card, size = 'preview', isCustomCard }) => {
   return card?.image_field ? (
@@ -108,6 +109,7 @@ const DocCard = ({ card, url, showEditor, children }) => {
             )}
           </div>
         )}
+      <CLMSTechnicalLibraryAdminInfo uid={card.UID} id={card['@id']} />
       <div className="card-doc-description">{card?.description}</div>
       {children}
     </>


### PR DESCRIPTION
I need the managers to be able to check the categorization of a given technical library item shown in related items listing (in Product and Dataset pages for instance)

We need this to let them check that the ordering is OK.

This should only be visible to Managers not to all logged-in users.